### PR TITLE
#21 [FIX] quiz 유형 제한 및 개수 제한

### DIFF
--- a/app/schemas/news_generate_schema.py
+++ b/app/schemas/news_generate_schema.py
@@ -75,6 +75,18 @@ class NewsGenerateResponse(BaseModel):
                         "question": "수요는 사람들이 상품이나 서비스를 사고자 하는 욕구를 의미한다.",
                         "answer": "O",
                         "explanation": "수요는 구매하고자 하는 의사와 필요를 뜻합니다.",
+                    },
+                    {
+                        "type": "OX",
+                        "question": "이 뉴스에서 수요는 자금이 필요한 상황과 연결된다.",
+                        "answer": "O",
+                        "explanation": "기사에서는 자금 필요와 금융 지원을 다루고 있습니다.",
+                    },
+                    {
+                        "type": "OX",
+                        "question": "뉴스 본문에 없는 내용도 정답 근거로 사용할 수 있다.",
+                        "answer": "X",
+                        "explanation": "퀴즈는 뉴스 본문에 있는 내용만 근거로 해야 합니다.",
                     }
                 ],
             }

--- a/app/services/news_quiz_service.py
+++ b/app/services/news_quiz_service.py
@@ -16,8 +16,8 @@ DEFAULT_DIFFICULTY = "BEGINNER"
 VALID_DIFFICULTIES = ("BEGINNER", "INTERMEDIATE", "ADVANCED")
 QUIZ_FIELD = "quiz"
 OX_TYPE = "OX"
-MULTIPLE_CHOICE_TYPE = "MULTIPLE_CHOICE"
 REQUIRED_QUIZ_FIELDS = ("type", "question", "answer", "explanation")
+REQUIRED_QUIZ_COUNT = 3
 
 DIFFICULTY_GUIDE = {
     "BEGINNER": "용어 뜻과 기사 핵심을 쉽게 묻는다.",
@@ -32,7 +32,7 @@ def generate_news_quiz(
     content: str,
     difficulty: str = DEFAULT_DIFFICULTY,
 ) -> list[dict[str, Any]]:
-    """Generate OX and multiple-choice quizzes from news content."""
+    """Generate OX quizzes from news content."""
     _validate_required_text(term, "term")
     _validate_required_text(title, "title")
     _validate_required_text(content, "content")
@@ -72,12 +72,9 @@ def build_quiz_prompt(
 - 과장된 표현을 쓰지 않는다.
 - 반드시 JSON만 반환한다.
 - 최상위 필드는 quiz 하나만 둔다.
-- quiz 배열에는 OX 문제 1개와 MULTIPLE_CHOICE 문제 1개를 포함한다.
+- quiz 배열에는 OX 문제만 정확히 3개 포함한다.
 - 각 문제에는 type, question, answer, explanation을 포함한다.
 - OX 문제의 answer는 반드시 "O" 또는 "X" 중 하나다.
-- MULTIPLE_CHOICE 문제는 options 배열을 포함하고, 보기는 정확히 4개만 만든다.
-- MULTIPLE_CHOICE 문제의 answer는 options 중 하나와 정확히 일치해야 한다.
-- 오답 보기는 너무 터무니없지 않게 만든다.
 - 해설은 경제 초급자도 이해할 수 있도록 쉽게 작성한다.
 - 마크다운 코드블록, 설명 문장, 번호 목록은 쓰지 않는다.
 
@@ -89,15 +86,20 @@ def build_quiz_prompt(
   "quiz": [
     {{
       "type": "OX",
-      "question": "O/X 문제 문장",
+      "question": "첫 번째 O/X 문제 문장",
       "answer": "O",
       "explanation": "쉬운 해설"
     }},
     {{
-      "type": "MULTIPLE_CHOICE",
-      "question": "객관식 문제 문장",
-      "options": ["보기 1", "보기 2", "보기 3", "보기 4"],
-      "answer": "보기 1",
+      "type": "OX",
+      "question": "두 번째 O/X 문제 문장",
+      "answer": "X",
+      "explanation": "쉬운 해설"
+    }},
+    {{
+      "type": "OX",
+      "question": "세 번째 O/X 문제 문장",
+      "answer": "O",
       "explanation": "쉬운 해설"
     }}
   ]
@@ -141,8 +143,12 @@ def validate_quiz_items(quiz: list[dict]) -> list[dict[str, Any]]:
     if not isinstance(quiz, list):
         raise ValueError("quiz must be a list.")
 
+    if len(quiz) != REQUIRED_QUIZ_COUNT:
+        raise ValueError(
+            f"quiz must include exactly {REQUIRED_QUIZ_COUNT} OX items."
+        )
+
     validated_quiz = []
-    seen_types = set()
 
     for index, item in enumerate(quiz, start=1):
         if not isinstance(item, dict):
@@ -153,22 +159,10 @@ def validate_quiz_items(quiz: list[dict]) -> list[dict[str, Any]]:
 
         if quiz_type == OX_TYPE:
             _validate_ox_quiz_item(normalized_item, index)
-        elif quiz_type == MULTIPLE_CHOICE_TYPE:
-            _validate_multiple_choice_quiz_item(normalized_item, index)
         else:
-            raise ValueError(
-                f"quiz item {index} has unsupported type: {quiz_type}"
-            )
+            raise ValueError(f"quiz item {index} must be OX type.")
 
-        seen_types.add(quiz_type)
         validated_quiz.append(normalized_item)
-
-    missing_types = {OX_TYPE, MULTIPLE_CHOICE_TYPE} - seen_types
-    if missing_types:
-        raise ValueError(
-            "quiz must include both OX and MULTIPLE_CHOICE items. "
-            f"Missing: {', '.join(sorted(missing_types))}"
-        )
 
     return validated_quiz
 
@@ -195,40 +189,6 @@ def _validate_common_quiz_fields(
 def _validate_ox_quiz_item(item: dict[str, Any], index: int) -> None:
     if item["answer"] not in {"O", "X"}:
         raise ValueError(f"OX quiz item {index} answer must be O or X.")
-
-
-def _validate_multiple_choice_quiz_item(
-    item: dict[str, Any],
-    index: int,
-) -> None:
-    options = item.get("options")
-    if not isinstance(options, list):
-        raise ValueError(
-            f"MULTIPLE_CHOICE quiz item {index} must include an options array."
-        )
-
-    cleaned_options = [
-        option.strip()
-        for option in options
-        if isinstance(option, str) and option.strip()
-    ]
-
-    if len(cleaned_options) != 4:
-        raise ValueError(
-            f"MULTIPLE_CHOICE quiz item {index} must include exactly 4 options."
-        )
-
-    if len(set(cleaned_options)) != 4:
-        raise ValueError(
-            f"MULTIPLE_CHOICE quiz item {index} options must be unique."
-        )
-
-    if item["answer"] not in cleaned_options:
-        raise ValueError(
-            f"MULTIPLE_CHOICE quiz item {index} answer must match one option."
-        )
-
-    item["options"] = cleaned_options
 
 
 def _normalize_difficulty(difficulty: str) -> str:
@@ -277,16 +237,16 @@ def print_quiz_parse_sample() -> None:
                     "explanation": "수요는 구매하거나 이용하려는 필요와 의사를 뜻합니다.",
                 },
                 {
-                    "type": "MULTIPLE_CHOICE",
-                    "question": "기사에서 자금 수요와 가장 관련 있는 내용은?",
-                    "options": [
-                        "중소기업의 자금 부담 완화",
-                        "소비자의 구매 감소",
-                        "세금 폐지",
-                        "수출 완전 중단",
-                    ],
-                    "answer": "중소기업의 자금 부담 완화",
-                    "explanation": "기사에서는 중소기업의 자금 조달 부담을 줄이는 금융 지원을 설명합니다.",
+                    "type": "OX",
+                    "question": "자금 수요는 기업의 금융 지원 필요와 관련될 수 있다.",
+                    "answer": "O",
+                    "explanation": "기사에서 자금 조달 부담과 금융 지원 필요를 다루기 때문입니다.",
+                },
+                {
+                    "type": "OX",
+                    "question": "뉴스 내용과 무관한 사실도 정답 근거로 사용할 수 있다.",
+                    "answer": "X",
+                    "explanation": "퀴즈는 뉴스 본문에 있는 내용만 근거로 만들어야 합니다.",
                 },
             ]
         },

--- a/docs/news_generate_api.md
+++ b/docs/news_generate_api.md
@@ -73,22 +73,16 @@ application/json
 | `pubDate` | `string \| null` | 뉴스 발행일 |
 | `summary` | `string[]` | GPT가 생성한 3줄 요약. 정확히 3개 문장을 기대한다. |
 | `keywordExplanation` | `string` | 경제 용어가 뉴스에서 어떻게 쓰였는지에 대한 쉬운 설명 |
-| `quiz` | `object[]` | 학습용 퀴즈 배열 |
+| `quiz` | `object[]` | 학습용 OX 퀴즈 배열. 정확히 3개 문항을 기대한다. |
 
 `quiz` 항목 공통 필드:
 
 | 필드 | 타입 | 설명 |
 | --- | --- | --- |
-| `type` | `"OX" \| "MULTIPLE_CHOICE"` | 퀴즈 유형 |
+| `type` | `"OX"` | 퀴즈 유형 |
 | `question` | `string` | 문제 |
 | `answer` | `string` | 정답 |
 | `explanation` | `string` | 해설 |
-
-`MULTIPLE_CHOICE` 추가 필드:
-
-| 필드 | 타입 | 설명 |
-| --- | --- | --- |
-| `options` | `string[]` | 객관식 보기. 4개 항목을 기대한다. |
 
 응답 예시:
 
@@ -115,16 +109,16 @@ application/json
       "explanation": "수요는 구매하고자 하는 의사와 필요를 뜻합니다."
     },
     {
-      "type": "MULTIPLE_CHOICE",
-      "question": "기사에서 수요와 가장 관련 있는 내용은 무엇인가요?",
-      "options": [
-        "자금이 필요한 기업이 늘어난 상황",
-        "가격이 완전히 사라진 상황",
-        "소비자가 없는 상황",
-        "시장이 폐쇄된 상황"
-      ],
-      "answer": "자금이 필요한 기업이 늘어난 상황",
+      "type": "OX",
+      "question": "기사에서 수요는 자금이 필요한 기업의 상황과 연결된다.",
+      "answer": "O",
       "explanation": "기사에서는 중소기업의 자금 필요가 늘어난 상황을 설명하고 있습니다."
+    },
+    {
+      "type": "OX",
+      "question": "뉴스 본문에 없는 내용도 퀴즈 정답 근거로 사용할 수 있다.",
+      "answer": "X",
+      "explanation": "퀴즈는 뉴스 본문에 있는 내용만 근거로 만들어야 합니다."
     }
   ]
 }
@@ -210,7 +204,7 @@ app/data/news.csv
   -> AI 서버가 뉴스 본문 전처리
   -> AI 서버가 GPT로 3줄 요약 생성
   -> AI 서버가 GPT로 경제 용어 설명 생성
-  -> AI 서버가 GPT로 OX/객관식 퀴즈 생성
+  -> AI 서버가 GPT로 OX 퀴즈 3문항 생성
   -> AI 서버가 JSON 반환
   -> 백엔드가 결과 저장 또는 프론트에 전달
 ```
@@ -257,7 +251,6 @@ Swagger 캡처가 필요하다면 이 화면에서 요청 body와 response body 
 - AI 서버 응답 생성에는 GPT 호출 시간이 포함되므로 일반 조회 API보다 응답 시간이 길 수 있다.
 - `category`는 선택값이다. 백엔드가 전달하지 않으면 AI 서버는 `term` 기준으로만 대표 뉴스를 찾는다.
 - `difficulty`는 생략 가능하며 기본값은 `BEGINNER`이다.
-- `quiz` 배열에는 `OX`와 `MULTIPLE_CHOICE` 문제가 포함될 수 있다.
-- 프론트에서 객관식 문제를 렌더링할 때는 `type === "MULTIPLE_CHOICE"`인 경우에만 `options`를 사용한다.
+- `quiz` 배열에는 `OX` 문제만 정확히 3개 포함된다.
 - `summary`는 3개 문장 배열로 내려오므로 프론트에서는 줄 단위 리스트로 표시하기 좋다.
 - `newsSummary`는 CSV에 있던 기존 요약이고, `summary`는 GPT가 새로 생성한 3줄 요약이다.

--- a/docs/news_generate_api_test.md
+++ b/docs/news_generate_api_test.md
@@ -45,7 +45,7 @@ uvicorn app.main:app --reload
 - `summary`는 문자열 3개를 가진 배열이다.
 - `keywordExplanation`은 비어 있지 않은 문자열이다.
 - `quiz`는 배열이며 각 문제에 `type`, `question`, `answer`, `explanation`이 포함된다.
-- `MULTIPLE_CHOICE` 문제에는 `options` 4개가 포함되고 `answer`는 options 중 하나와 정확히 일치한다.
+- `quiz`는 OX 문제만 정확히 3개 포함한다.
 
 ### category 포함
 
@@ -88,16 +88,16 @@ uvicorn app.main:app --reload
       "explanation": "수요는 어떤 것을 필요로 하거나 구매하려는 의사를 뜻합니다."
     },
     {
-      "type": "MULTIPLE_CHOICE",
-      "question": "기사에서 중소기업의 자금 수요와 가장 관련 있는 내용은?",
-      "options": [
-        "자금 조달 부담을 줄이기 위한 금융 지원",
-        "소비자의 구매 감소",
-        "세금 폐지",
-        "수출의 완전 중단"
-      ],
-      "answer": "자금 조달 부담을 줄이기 위한 금융 지원",
+      "type": "OX",
+      "question": "기사에서 중소기업의 자금 수요는 금융 지원과 관련이 있다.",
+      "answer": "O",
       "explanation": "기사에서는 중소기업의 자금 부담을 낮추기 위한 지원 프로그램을 설명합니다."
+    },
+    {
+      "type": "OX",
+      "question": "뉴스 본문에 없는 내용도 정답 근거로 사용할 수 있다.",
+      "answer": "X",
+      "explanation": "퀴즈는 뉴스 본문에 있는 내용만 근거로 만들어야 합니다."
     }
   ]
 }
@@ -240,11 +240,10 @@ type NewsGenerateResponse = {
   summary: string[];
   keywordExplanation: string;
   quiz: Array<{
-    type: "OX" | "MULTIPLE_CHOICE";
+    type: "OX";
     question: string;
     answer: string;
     explanation: string;
-    options?: string[];
   }>;
 };
 ```
@@ -262,8 +261,8 @@ type NewsGenerateResponse = {
 - [ ] 정상 요청 시 `200 OK`가 반환된다.
 - [ ] `summary` 배열 길이가 3이다.
 - [ ] `keywordExplanation`이 비어 있지 않다.
-- [ ] `quiz` 배열에 OX와 객관식 문제가 포함된다.
-- [ ] 객관식 `answer`가 `options` 중 하나와 정확히 일치한다.
+- [ ] `quiz` 배열에 OX 문제가 정확히 3개 포함된다.
+- [ ] 모든 퀴즈의 `answer`가 `O` 또는 `X`이다.
 - [ ] 없는 term 요청 시 404가 반환된다.
 - [ ] 잘못된 difficulty 요청 시 422가 반환된다.
 - [ ] OpenAI API Key 누락 시 명확한 500 에러가 반환된다.

--- a/docs/render_deploy.md
+++ b/docs/render_deploy.md
@@ -168,7 +168,7 @@ curl -X POST "https://your-service-name.onrender.com/ai/news/generate" \
 - `200 OK`
 - `term`, `newsTitle`, `newsUrl`, `summary`, `keywordExplanation`, `quiz` 포함
 - `summary`는 3개 문장 배열
-- `quiz`에는 OX와 객관식 문제가 포함될 수 있음
+- `quiz`에는 OX 문제가 정확히 3개 포함됨
 
 OpenAI API 호출이 포함되므로 응답까지 시간이 걸릴 수 있다.
 

--- a/tests/test_news_generate_api.py
+++ b/tests/test_news_generate_api.py
@@ -2,9 +2,99 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 from app.routers import news_generate_router
+from app.services.news_quiz_service import parse_quiz_response
 
 
 client = TestClient(app)
+
+
+def test_parse_quiz_response_allows_exactly_three_ox_items():
+    response_text = """
+    {
+      "quiz": [
+        {
+          "type": "OX",
+          "question": "수요는 필요와 구매 의사를 뜻한다.",
+          "answer": "O",
+          "explanation": "수요는 필요와 구매 의사를 포함합니다."
+        },
+        {
+          "type": "OX",
+          "question": "뉴스 내용과 경제 용어는 연결될 수 있다.",
+          "answer": "O",
+          "explanation": "기사 속 상황을 경제 용어로 설명할 수 있습니다."
+        },
+        {
+          "type": "OX",
+          "question": "본문에 없는 내용을 정답 근거로 삼아도 된다.",
+          "answer": "X",
+          "explanation": "정답 근거는 뉴스 본문에 있어야 합니다."
+        }
+      ]
+    }
+    """
+
+    quiz = parse_quiz_response(response_text)
+
+    assert len(quiz) == 3
+    assert {item["type"] for item in quiz} == {"OX"}
+
+
+def test_parse_quiz_response_rejects_non_ox_items():
+    response_text = """
+    {
+      "quiz": [
+        {
+          "type": "OX",
+          "question": "문제 1",
+          "answer": "O",
+          "explanation": "해설 1"
+        },
+        {
+          "type": "MULTIPLE_CHOICE",
+          "question": "문제 2",
+          "options": ["보기 1", "보기 2", "보기 3", "보기 4"],
+          "answer": "보기 1",
+          "explanation": "해설 2"
+        },
+        {
+          "type": "OX",
+          "question": "문제 3",
+          "answer": "X",
+          "explanation": "해설 3"
+        }
+      ]
+    }
+    """
+
+    try:
+        parse_quiz_response(response_text)
+    except ValueError as exc:
+        assert "must be OX type" in str(exc)
+    else:
+        raise AssertionError("Expected non-OX quiz item to be rejected.")
+
+
+def test_parse_quiz_response_rejects_wrong_quiz_count():
+    response_text = """
+    {
+      "quiz": [
+        {
+          "type": "OX",
+          "question": "문제 1",
+          "answer": "O",
+          "explanation": "해설 1"
+        }
+      ]
+    }
+    """
+
+    try:
+        parse_quiz_response(response_text)
+    except ValueError as exc:
+        assert "exactly 3 OX items" in str(exc)
+    else:
+        raise AssertionError("Expected wrong quiz count to be rejected.")
 
 
 def test_generate_news_success(monkeypatch):
@@ -35,11 +125,16 @@ def test_generate_news_success(monkeypatch):
                     "explanation": "수요는 필요와 구매 의사를 뜻합니다.",
                 },
                 {
-                    "type": "MULTIPLE_CHOICE",
-                    "question": "기사에서 수요와 가장 관련 있는 내용은?",
-                    "options": ["자금 지원", "세금 폐지", "수출 중단", "소비 감소"],
-                    "answer": "자금 지원",
+                    "type": "OX",
+                    "question": "기사에서는 자금 지원과 관련된 내용을 설명한다.",
+                    "answer": "O",
                     "explanation": "기사에서는 자금 지원을 설명합니다.",
+                },
+                {
+                    "type": "OX",
+                    "question": "수요는 기사 내용과 전혀 연결되지 않는다.",
+                    "answer": "X",
+                    "explanation": "수요는 기사 속 자금 필요와 연결됩니다.",
                 },
             ],
         }
@@ -62,8 +157,9 @@ def test_generate_news_success(monkeypatch):
     assert body["newsUrl"] == "https://example.com/news"
     assert len(body["summary"]) == 3
     assert body["keywordExplanation"]
-    assert len(body["quiz"]) == 2
+    assert len(body["quiz"]) == 3
     for quiz_item in body["quiz"]:
+        assert quiz_item["type"] == "OX"
         assert quiz_item["question"]
         assert quiz_item["answer"]
         assert quiz_item["explanation"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#21

## 📝 작업 내용

AI 뉴스 퀴즈 생성 기능을 수정하여 OX 퀴즈만 생성되도록 제한하고, 항상 3개의 문항이 반환되도록 검증 로직을 추가하였습니다.

### 변경 사항

* 퀴즈 생성 프롬프트를 OX 퀴즈 3문항 기준으로 수정
* 객관식(MCQ) 생성 및 검증 로직 제거
* 응답 검증 로직에 문항 수(3개) 및 OX 타입 검증 추가
* Swagger 예시를 OX 퀴즈 3문항 형식으로 수정
* 관련 문서 업데이트
* OX 3문항 성공 케이스 및 예외 케이스 테스트 추가